### PR TITLE
Updating version number to 1.5.7

### DIFF
--- a/cpuset/version.py
+++ b/cpuset/version.py
@@ -16,4 +16,4 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 """
 
-version = '1.5.6'
+version = '1.5.7'


### PR DESCRIPTION
While downloading the package, it says the version number is 1.5.7 but it has not been changed in the version file.