### PR TITLE
Fix bug caused by misplaced closing parentheses

### DIFF
--- a/cpuset/commands/set.py
+++ b/cpuset/commands/set.py
@@ -484,7 +484,7 @@ def set_details(name, indent=None, width=None, usehex=False):
     if width != 0 and len(tst) > width:
         target = width - len(out)
         patha = set.path[:len(set.path)//2-3]
-        pathb = set.path[len(set.path//2):]
+        pathb = set.path[len(set.path)//2:]
         patha = patha[:target//2-3]
         pathb = pathb[-target//2:]
         out += patha + '...' + pathb


### PR DESCRIPTION
This command:
[edit lpechacek] `$ cset shield -c $(seq 10 2 127 | tr \\n , | sed 's/,$//')`
`$ cset set -r -l`

Results in the following:
```
Traceback (most recent call last):
  File "/usr/bin/cset", line 47, in <module>
    main()
  File "/usr/lib/python3/dist-packages/cpuset/main.py", line 234, in main
    command.func(parser, options, args)
  File "/usr/lib/python3/dist-packages/cpuset/commands/set.py", line 186, in func
    else: list_sets('root', options.recurse, options.usehex)
  File "/usr/lib/python3/dist-packages/cpuset/commands/set.py", line 243, in list_sets
    pl.append(set_details(s,' ', 78, usehex))
  File "/usr/lib/python3/dist-packages/cpuset/commands/set.py", line 487, in set_details
    pathb = set.path[len(set.path//2):]
TypeError: unsupported operand type(s) for //: 'str' and 'int'
```
This is caused by misplaced closing parenthesis for len(). Moving it to the correct place produces the desired output.