### PR TITLE
Fix --syset typo

### DIFF
--- a/cpuset/commands/shield.py
+++ b/cpuset/commands/shield.py
@@ -98,7 +98,7 @@ initialize these cpusets and dedicate CPU0 and CPU1 to the "free"
 set and (on a 4-way machine) dedicate CPU2 and CPU3 to the "cage"
 set.  Further, the command moves all processes and threads,
 including kernel threads from the root cpuset to the "free"
-cpuset.  Note however that if you do use the --syset/--userset
+cpuset.  Note however that if you do use the --sysset/--userset
 options, then you must continue to use those for every invocation
 of the shield supercommand.
 

--- a/doc/cset-shield.1
+++ b/doc/cset-shield.1
@@ -170,7 +170,7 @@ The above command will use the name "free" for the unshielded system cpuset, the
 \fBNote\fR
 .ps -1
 .br
-If you do use the \-\-syset/\-\-userset options, then you must continue to use those for every invocation of the shield supercommand\&.
+If you do use the \-\-sysset/\-\-userset options, then you must continue to use those for every invocation of the shield supercommand\&.
 .sp .5v
 .RE
 After initialization, you can run the process of interest on the shielded cpuset with the \-\-exec subcommand, or move processes or threads already running to the shielded cpuset with the \-\-shield subcommand and the \-\-pid option\&.

--- a/doc/cset-shield.html
+++ b/doc/cset-shield.html
@@ -951,7 +951,7 @@ cpuset.</p></div>
 <td class="icon">
 <div class="title">Note</div>
 </td>
-<td class="content">If you do use the --syset/--userset options, then you must
+<td class="content">If you do use the --sysset/--userset options, then you must
 continue to use those for every invocation of the shield supercommand.</td>
 </tr></table>
 </div>

--- a/doc/cset-shield.txt
+++ b/doc/cset-shield.txt
@@ -137,7 +137,7 @@ set.  Further, the command moves all processes and threads,
 including kernel threads from the root cpuset to the "free"
 cpuset.  
 
-NOTE: If you do use the --syset/--userset options, then you must
+NOTE: If you do use the --sysset/--userset options, then you must
 continue to use those for every invocation of the shield supercommand.
 
 After initialization, you can run the process of interest on the


### PR DESCRIPTION
--sysset was mistakenly written as --syset in various places in the documentations.

Batch replaced with sed.