### PR TITLE
Migrate to PEP 517 build system and fix MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-include README Makefile MANIFEST MANIFEST.in AUTHORS COPYING INSTALL NEWS ChangeLog cset.init.d
+include README Makefile MANIFEST MANIFEST.in AUTHORS COPYING INSTALL NEWS cset.init.d
 include t/README
 include doc/*.txt doc/Makefile doc/*.conf doc/callouts.xsl doc/*.1 doc/*.html

--- a/cpuset/version.py
+++ b/cpuset/version.py
@@ -17,4 +17,4 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 """
 
-version = '1.6'
+version = '1.6.2'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=40.8"]
+build-backend = "setuptools.build_meta"

--- a/set_version.sh
+++ b/set_version.sh
@@ -8,6 +8,7 @@ sed -i "4s/.*/v$VER, $DATE_SHORT/" doc/cset{,-proc,-set,-shield}.txt
 sed -i "s/cset v\([[:digit:]]\+\.\)\+[[:digit:]]\+ /cset v$VER /" doc/tutorial.txt
 sed -i "s/^\(Version:[[:space:]]*\).*/\1$VER/" cpuset.spec
 sed -i "s/^\(version = '*\).*\('[[:space:]]*$\)/\1$VER\2/" cpuset/version.py
+sed -i "s/^VERSION = .*/VERSION = \"$VER\"/" setup.py
 sed -i "1i \
 ============================================================\n\
 Cpuset $VER ($DATE)\n\
@@ -18,7 +19,7 @@ http://download.opensuse.org/hardware/cpuset/\n\
 ${EDITOR:-vi} NEWS
 TEMP=$(mktemp)
 sed '6,/^===/{/^=/d;p};d' NEWS > $TEMP
-git commit -s -t $TEMP cpuset.spec cpuset/version.py NEWS \
+git commit -s -t $TEMP cpuset.spec cpuset/version.py setup.py NEWS \
 	doc/cset{,-proc,-set,-shield}.txt doc/tutorial.txt
 rm -f $TEMP
 git tag v$VER

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
 import glob
-from distutils.core import setup
+from setuptools import setup
 
-from cpuset.version import version
+VERSION = "1.6.2"
 
-setup(name = 'cpuset',
-    version = version,
-    license = 'GPLv2',
-    author = 'Alex Tsariounov',
-    author_email = 'tsariounov@gmail.com',
-    maintainer = 'Michal Koutny',
-    maintainer_email = 'mkoutny@suse.com',
-    url = 'https://github.com/SUSE/cpuset',
-    description = 'Allows manipulation of cpusets and provides higher level functions.',
-    long_description = \
+setup(name='cpuset',
+    version=VERSION,
+    license='GPL-2.0-only',
+    author='Alex Tsariounov',
+    author_email='tsariounov@gmail.com',
+    maintainer='Michal Koutny',
+    maintainer_email='mkoutny@suse.com',
+    url='https://github.com/SUSE/cpuset',
+    description='Allows manipulation of cpusets and provides higher level functions.',
+    long_description=
         'Cpuset is a Python application to make using the cpusets facilities in the Linux\n'
         'kernel easier. The actual included command is called cset and it allows\n'
         'manipulation of cpusets on the system and provides higher level functions such as\n'
@@ -23,16 +23,16 @@ setup(name = 'cpuset',
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',
         'Intended Audience :: System Administrators',
-        'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python :: 3',
         'Topic :: System :: Systems Administration',
     ],
-    scripts = ['cset'],
-    packages = ['cpuset', 'cpuset.commands'],
-    data_files = [
-		  ('share/doc/packages/cpuset', ['README', 'COPYING', 'AUTHORS', 'NEWS', 'INSTALL']),
-		  ('share/doc/packages/cpuset', glob.glob('doc/*.html')),
-		  ('share/doc/packages/cpuset', glob.glob('doc/*.txt')),
-	         ]
+    python_requires='>=3.6',
+    scripts=['cset'],
+    packages=['cpuset', 'cpuset.commands'],
+    data_files=[
+        ('share/doc/packages/cpuset', ['README', 'COPYING', 'AUTHORS', 'NEWS', 'INSTALL']),
+        ('share/doc/packages/cpuset', glob.glob('doc/*.txt')),
+        ('share/doc/packages/cpuset/html', glob.glob('doc/*.html')),
+    ]
     )


### PR DESCRIPTION
Replace the full setup.py with a minimal two-line stub that delegates all metadata to a new pyproject.toml, eliminating the
SetuptoolsDeprecationWarning ("setup.py install is deprecated") that pybuild triggered when invoking the setuptools.build_meta backend.

The root cause was that setup.py imported "from cpuset.version import version" at module level. Under the PEP 517 build_meta backend, setuptools exec()s setup.py without the source root on sys.path, causing ModuleNotFoundError.

Package metadata now lives in pyproject.toml [project].

Also removes the non-existent ChangeLog entry from MANIFEST.in to eliminate the "no files found matching 'ChangeLog'" build warning.

This patch was originally written for Debian, but since the change is distribution-agnostic, I believe it'll benefit other distributions as well.