### PR TITLE
Remove and prevent obsolete an-trap requests in manpages

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -56,6 +56,7 @@ clean:
 
 %.1 %.7 : %.xml
 	xmlto -m callouts.xsl man $<
+	sed -i '/^\.it 1 an-trap$$/d' $@
 
 %.xml : %.txt
 	$(ASCIIDOC) -b docbook -d manpage -f asciidoc.conf $<

--- a/doc/cset-proc.1
+++ b/doc/cset-proc.1
@@ -162,7 +162,6 @@ For example:
 .sp
 .\}
 .RS 4
-.it 1 an-trap
 .nr an-no-space-flag 1
 .nr an-break-flag 1
 .br
@@ -188,7 +187,6 @@ Specifying the \-\-fromset is not necessary since the tasks will be moved to the
 .sp
 .\}
 .RS 4
-.it 1 an-trap
 .nr an-no-space-flag 1
 .nr an-break-flag 1
 .br
@@ -212,7 +210,6 @@ This command specifies that all processes and threads running on cpuset "comp1" 
 .sp
 .\}
 .RS 4
-.it 1 an-trap
 .nr an-no-space-flag 1
 .nr an-break-flag 1
 .br
@@ -227,7 +224,6 @@ This move command will not move kernel threads unless the \-k/\-\-kthread switch
 .sp
 .\}
 .RS 4
-.it 1 an-trap
 .nr an-no-space-flag 1
 .nr an-break-flag 1
 .br

--- a/doc/cset-shield.1
+++ b/doc/cset-shield.1
@@ -130,7 +130,6 @@ One executes processes on the shielded user cpuset with the \-\-exec subcommand 
 .sp
 .\}
 .RS 4
-.it 1 an-trap
 .nr an-no-space-flag 1
 .nr an-break-flag 1
 .br
@@ -162,7 +161,6 @@ The above command will use the name "free" for the unshielded system cpuset, the
 .sp
 .\}
 .RS 4
-.it 1 an-trap
 .nr an-no-space-flag 1
 .nr an-break-flag 1
 .br
@@ -206,7 +204,6 @@ The above command moves all processes and threads with PID or TID in the range 5
 .sp
 .\}
 .RS 4
-.it 1 an-trap
 .nr an-no-space-flag 1
 .nr an-break-flag 1
 .br
@@ -236,7 +233,6 @@ The \-\-reset subcommand will in essence destroy the shield\&. For example, if t
 .sp
 .\}
 .RS 4
-.it 1 an-trap
 .nr an-no-space-flag 1
 .nr an-break-flag 1
 .br

--- a/doc/cset.1
+++ b/doc/cset.1
@@ -41,7 +41,6 @@ cset \- manage cpusets functions in the Linux kernel
 .sp
 .\}
 .RS 4
-.it 1 an-trap
 .nr an-no-space-flag 1
 .nr an-break-flag 1
 .br


### PR DESCRIPTION
doc/Makefile builds man pages in two steps: asciidoc converts each doc/*.txt source to DocBook XML, then "xmlto man" converts that XML to groff via the system's DocBook XSL "manpages" stylesheets. Those stylesheets emit a ".it 1 an-trap" line for every Note/Warning/Important admonition but never define the an-trap macro in that context, so modern groff and mandoc warn about it. This is a docbook-xsl bug; cpuset's own doc/asciidoc.conf and doc/callouts.xsl have no influence over it.

This patch removes the existing an-trap lines from the .1 files already shipped in the orig tarball, and adds a sed post-processing step to the %.1/%.7 rule in doc/Makefile so a future "make -C doc" regeneration produces clean output too.